### PR TITLE
Fix 'n.replace is not a function' error.

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,9 +55,14 @@ const spaceCharRegex = /(-|\.|_|\/|~)/g
 function map (msg) {
   return getMentions(msg)
     .filter(isBlobMention)
+    .filter(blobHasName)
     .map(m => m.name)
     .map(n => n.replace(imgExtRegEx, '').replace(spaceCharRegex, ' '))
     .join(' ')
+}
+
+function blobHasName(mention) {
+  return typeof(mention.name) === "string"
 }
 
 function getMentions (msg) {

--- a/index.js
+++ b/index.js
@@ -32,6 +32,7 @@ module.exports = {
           const result = data.reduce((soFar, msg) => {
             getMentions(msg)
               .filter(isBlobMention)
+              .filter(blobHasName)
               .filter(m => m.name.indexOf(opts.query) > -1) // only mentions relevant to the query
               .forEach(({ link, name }) => {
                 if (!soFar[link]) soFar[link] = []


### PR DESCRIPTION
When I open patchbay I get the following error:

```
TypeError: n.replace is not a function
    at getMentions.filter.map.n (/home/happy0/projects/patchbay/node_modules/ssb-meme/index.js:59:17)
    at Array.map (native)
    at map (/home/happy0/projects/patchbay/node_modules/ssb-meme/index.js:59:6)
    at /home/happy0/projects/patchbay/node_modules/ssb-meme/node_modules/flumeview-search/index.js:14:16
    at reduce (/home/happy0/projects/patchbay/node_modules/ssb-meme/node_modules/flumeview-level/index.js:90:25)
    at /home/happy0/projects/patchbay/node_modules/pull-write/index.js:35:23
    at /home/happy0/projects/patchbay/node_modules/pull-write/index.js:41:13
    at /home/happy0/projects/patchbay/node_modules/pull-cursor/skip.js:14:16
    at /home/happy0/projects/patchbay/node_modules/pull-cursor/cursor.js:32:13
    at /home/happy0/projects/patchbay/node_modules/flumelog-offset/inject.js:55:9
```
This pull request attempts to fix that.

I'm using 'typeof' rather than a null / undefined check to protect against malformed messages.

Not sure if this is the best approach or not. Would something else be more appropriate?

Fixes #1 